### PR TITLE
Add dummy world_utm -> sam_odom tf transformation

### DIFF
--- a/auv_ekf_localization/include/sonar_manipulator/sonar_manipulator.hpp
+++ b/auv_ekf_localization/include/sonar_manipulator/sonar_manipulator.hpp
@@ -18,6 +18,7 @@
 #include <ros/ros.h>
 #include <tf/transform_datatypes.h>
 #include <tf/tf.h>
+#include <numeric>
 
 /**
  * @brief The SonarManipulator class

--- a/sam_dead_reckoning/launch/sam_gps_dummy.launch
+++ b/sam_dead_reckoning/launch/sam_gps_dummy.launch
@@ -31,13 +31,11 @@
     <node pkg="sam_dead_reckoning" type="publish_gps_path.py" name="publish_gps_path" output="screen"/>
     <node pkg="sam_dead_reckoning" type="spoof_gps_imu.py" name="spoof_gps_imu" output="screen"/>
 
-    <!--
     <node pkg="nmea_navsat_driver" type="nmea_serial_driver" name="navsat" respawn="true">
         <param name="port" value="$(arg gps_port)"/>
         <param name="baud" value="$(arg gps_baud)"/>
         <param name="frame_id" value="$(arg gps_frame_id)"/>
     </node>
-    -->
 
     <include file="$(find sam_dead_reckoning)/launch/sam_stim_dr.launch">
         <arg name="namespace" default="$(arg namespace)"/>

--- a/sam_dead_reckoning/launch/sam_gps_dummy.launch
+++ b/sam_dead_reckoning/launch/sam_gps_dummy.launch
@@ -1,0 +1,49 @@
+<launch>
+
+    <arg name="namespace" default="sam"/>
+    <arg name="mode" default="default"/>
+    <arg name="debug" default="0"/>
+    <arg name="gps_port" value="/dev/ttyUSB2"/>
+    <arg name="gps_baud" value="9600"/>
+    <arg name="gps_frame_id" value="gps"/>
+
+    <!-- Get these coordinates by clicking in Google maps and converting lat/lon to UTM -->
+    <arg name="latitude" default="59.348513"/>
+    <arg name="longitude" default="18.071553"/>
+    <!-- UTM Zone: 34V -->
+    <arg name="utm_easting" default="333492.08"/>
+    <arg name="utm_northing" default="6582522.08"/>
+
+    <node pkg="tf" type="static_transform_publisher" name="world_utm_broadcaster" args="$(arg utm_easting) $(arg utm_northing) 0 0 0 0 1 world_utm world_local 100" />
+    <!-- This is required for the Aerial map display to work properly" -->
+    <node pkg="tf" type="static_transform_publisher" name="map_utm_broadcaster" args="0 0 0 0 0 0 1 map world_utm 100" />
+
+    <node pkg="rostopic" type="rostopic" name="fake_gps_fix"
+          args="pub /fake_fix sensor_msgs/NavSatFix --latch
+          '{header: {seq: 999, stamp: {secs: 0, nsecs: 0}, frame_id: 'world_local'},
+            status: {status: 0, service: 1},
+            latitude: $(arg latitude),
+            longitude: $(arg longitude),
+            altitude: 0,
+            position_covariance: [3.9561210000000004, 0.0, 0.0, 0.0, 3.9561210000000004, 0.0, 0.0, 0.0, 7.650756],
+            position_covariance_type: 2}'" output="screen"/>
+
+    <node pkg="sam_dead_reckoning" type="publish_gps_path.py" name="publish_gps_path" output="screen"/>
+    <node pkg="sam_dead_reckoning" type="spoof_gps_imu.py" name="spoof_gps_imu" output="screen"/>
+
+    <!--
+    <node pkg="nmea_navsat_driver" type="nmea_serial_driver" name="navsat" respawn="true">
+        <param name="port" value="$(arg gps_port)"/>
+        <param name="baud" value="$(arg gps_baud)"/>
+        <param name="frame_id" value="$(arg gps_frame_id)"/>
+    </node>
+    -->
+
+    <include file="$(find sam_dead_reckoning)/launch/sam_stim_dr.launch">
+        <arg name="namespace" default="$(arg namespace)"/>
+        <arg name="mode" default="$(arg mode)"/>
+        <arg name="debug" default="$(arg debug)"/>
+    </include>
+
+
+</launch>

--- a/sam_dead_reckoning/scripts/publish_gps_path.py
+++ b/sam_dead_reckoning/scripts/publish_gps_path.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python
+
+import rospy
+import numpy as np
+import math
+from sensor_msgs.msg import Imu, NavSatFix
+from geometry_msgs.msg import PoseWithCovarianceStamped, TwistStamped, Quaternion, Point
+import tf_conversions
+import tf
+from geodesy import utm
+from nav_msgs.msg import Odometry
+
+class GPSOdomPublisher(object):
+
+    def __init__(self):
+        self.gps_topic = rospy.get_param(rospy.get_name() + '/gps_topic', '/fix')
+        self.imu_topic = rospy.get_param(rospy.get_name() + '/imu_topic', '/heading_imu')
+
+        self.gps_sub = rospy.Subscriber(self.gps_topic, NavSatFix, self.gps_callback)
+        self.imu_sub = rospy.Subscriber(self.imu_topic, Imu, self.imu_callback)
+
+        self.odom_topic = "sam/utm_odom"
+        self.odom_frame = "world_utm"
+        self.odom_pub = rospy.Publisher(self.odom_topic, Odometry)
+
+        self.odom_msg = Odometry()
+        self.odom_msg.header.frame_id = self.odom_frame
+        #self.odom_msg.pose.covariance = [.5, 0., 0., 0., .5, 0., 0., 0., .5]
+        #self.odom_msg.pose.pose.orientation.w = 1.
+        self.odom_msg.pose.pose.orientation = Quaternion(*[0., 0., 0., 1.])
+
+        self.br = tf.TransformBroadcaster()
+        self.listener = tf.TransformListener()
+
+        rospy.spin()
+
+    def imu_callback(self, imu_msg):
+
+        print "Got IMU callback!"
+        self.odom_msg.pose.pose.orientation = imu_msg.orientation
+
+    def gps_callback(self, gps_msg):
+        if gps_msg.status == -1:
+            return
+        try:
+            utm_point = utm.fromLatLong(gps_msg.latitude, gps_msg.longitude)
+        except ValueError:
+            return
+        print utm_point.gridZone()
+        easting = utm_point.easting
+        northing = utm_point.northing
+
+        self.odom_msg.pose.pose.position = Point(*[easting, northing, 0.])
+
+        self.odom_pub.publish(self.odom_msg)
+
+        try:
+            now = rospy.Time(0)
+            (odom_trans, odom_rot) = self.listener.lookupTransform("sam_odom", "sam/base_link", now)
+            #(odom_trans, odom_rot) = self.listener.lookupTransform("sam/base_link", "sam_odom", now)
+            odom_transform = tf.transformations.concatenate_matrices(tf.transformations.translation_matrix(odom_trans), tf.transformations.quaternion_matrix(odom_rot))
+        except (tf.LookupException, tf.ConnectivityException):
+            print "Could not get transform between ", "sam_odom", "and", "sam/base_link"
+            return
+
+        try:
+            now = rospy.Time(0)
+            (world_trans, world_rot) = self.listener.lookupTransform("world_utm", "world_local", now)
+            #(world_trans, world_rot) = self.listener.lookupTransform("world_local", "world_utm", now)
+            world_transform = tf.transformations.concatenate_matrices(tf.transformations.translation_matrix(world_trans), tf.transformations.quaternion_matrix(world_rot))
+        except (tf.LookupException, tf.ConnectivityException):
+            print "Could not get transform between ", "world_utm", "and", "world_local"
+            return
+
+        gps_trans = [easting, northing, 0.]
+        gps_rot = [self.odom_msg.pose.pose.orientation.x, self.odom_msg.pose.pose.orientation.y, self.odom_msg.pose.pose.orientation.z, self.odom_msg.pose.pose.orientation.w]
+        gps_transform = tf.transformations.concatenate_matrices(tf.transformations.translation_matrix(gps_trans), tf.transformations.quaternion_matrix(gps_rot))
+        
+
+        print "Got pose: ", odom_trans, odom_rot
+        print "Got odom matrix: ", odom_transform
+        print "Got world matrix: ", world_transform
+        print "Got gps matrix: ", gps_transform
+
+        correction = np.dot(np.dot(tf.transformations.inverse_matrix(world_transform), gps_transform), tf.transformations.inverse_matrix(odom_transform))
+        print "got correction", correction
+
+        correction_trans = tf.transformations.translation_from_matrix(correction)
+        correction_rot = tf.transformations.quaternion_from_matrix(correction)
+
+        self.br.sendTransform(correction_trans,
+                     correction_rot,
+                     rospy.Time.now(),
+                     "world",
+                     "world_local")
+
+        print "Published transform!"
+
+
+if __name__ == "__main__":
+
+    rospy.init_node('spoof_gps_imu')
+    try:
+        node = GPSOdomPublisher()
+    except rospy.ROSInterruptException:
+        pass

--- a/sam_dead_reckoning/scripts/spoof_depth.py
+++ b/sam_dead_reckoning/scripts/spoof_depth.py
@@ -8,8 +8,8 @@ from geometry_msgs.msg import PoseWithCovarianceStamped
 class SpoofDepth(object):
 
 	def __init__(self):
-		self.odom_frame = rospy.get_param(rospy.get_name() + '/odom_frame', '/odom')
-		self.depth_topic = rospy.get_param(rospy.get_name() + '/depth_topic', '/depth')
+		self.odom_frame = rospy.get_param(rospy.get_name() + '/odom_frame', 'sam/base_link')
+		self.depth_topic = rospy.get_param(rospy.get_name() + '/depth_topic', '/uavcan_depth2')
 
 		self.pub = rospy.Publisher(self.depth_topic, PoseWithCovarianceStamped)
 

--- a/sam_dead_reckoning/scripts/spoof_gps_imu.py
+++ b/sam_dead_reckoning/scripts/spoof_gps_imu.py
@@ -6,19 +6,20 @@ import math
 from sensor_msgs.msg import Imu, NavSatFix
 from geometry_msgs.msg import PoseWithCovarianceStamped, TwistStamped, Quaternion
 import tf_conversions
+import tf
 from geodesy import utm
-from nav_msgs import Odometry
+from nav_msgs.msg import Odometry
 
 class SpoofIMU(object):
 
     def __init__(self):
-        self.imu_frame =  rospy.get_param(rospy.get_name() + '/imu_frame', '/sam/base_link')
+        self.imu_frame =  rospy.get_param(rospy.get_name() + '/imu_frame', 'sam/base_link')
         self.gps_topic = rospy.get_param(rospy.get_name() + '/gps_topic', '/fix')
         self.vel_topic = rospy.get_param(rospy.get_name() + '/vel_topic', '/vel')
         self.heading_imu_topic = rospy.get_param(rospy.get_name() + '/heading_imu_topic', '/heading_imu')
-        self.odom_topic = '/odom'
+        self.odom_topic = '/odometry/filtered/sam'
 
-        if False:
+        if True:
             self.gps_sub = rospy.Subscriber(self.gps_topic, NavSatFix, self.gps_callback)
         else:
             self.vel_sub = rospy.Subscriber(self.vel_topic, TwistStamped, self.vel_callback)
@@ -30,7 +31,7 @@ class SpoofIMU(object):
         self.imu_msg.orientation_covariance = [.5, 0., 0., 0., .5, 0., 0., 0., .5]
         #self.imu_msg.pose.pose.orientation.w = 1.
 
-        self.window = 10
+        self.window = 5
         self.positions = []
         self.vels = []
         self.roll = 0.


### PR DESCRIPTION
This will add a transformation world_utm -> sam_odom that means that all world_utm -> base_link transformations will be in the correct coordinate system (i.e. georeferenced). Note that all sam_odom -> base_link transformations stay the same. This is irrespective of the dead reckoning running on sam, as it takes the DR estimate as input. So inbetween GPS measurements, sam can rely on the dead reckoning translation and orientation.

To launch:
```
roslaunch sam_dead_reckoning sam_gps_dummy.launch
```

Note that this requires the nmea_navsat_driver package (to run the GPS). It is part of the ROS package dist and can be installed e.g. by:
```
sudo apt install ros-melodic-nmea-navsat-driver
```

If you want a satellite map to view the robot in the map, clone this repo in your catkin ws: https://github.com/gareth-cross/rviz_satellite
Then build and source your ws before opening rviz and add a "AerialMapDisplay" in rviz.
Use the config: `Topic: /fake_fix`, `Object URI: https://a.tile.openstreetmap.org/{z}/{x}/{y}.png` and `Frame Convention: XYZ->ENU`.

After this change, the TF link structure looks like this:
```
world_utm -> world_local -> world -> sam_odom -> sam/base_link
```
`world_utm` now gives us the reference frame of the local utm grid.

@ignaciotb I have tested this with GPS and IMU and it should be good to go.